### PR TITLE
prevent Json.decode call on leading 0 strings

### DIFF
--- a/lib/ruote/sequel/storage.rb
+++ b/lib/ruote/sequel/storage.rb
@@ -347,7 +347,7 @@ puts "put: got exception #{de.to_s}, try number #{i + 1}"
       ds = ds.filter(:participant_name => pname) if pname
 
       criteria.collect do |k, v|
-        if v.to_s =~ /^\d+$/
+        if v.to_s =~ /^[1-9]\d*$/
           ds = ds.filter(::Sequel.like(:doc, "%\"#{k}\":#{Rufus::Json.encode(v.to_s)}%", "%\"#{k}\":#{Rufus::Json.decode(v.to_s)}%"))
         else
           ds = ds.filter(::Sequel.like(:doc, "%\"#{k}\":#{Rufus::Json.encode(v)}%"))


### PR DESCRIPTION
### Base branch(merging into):

release/1.0
### Pivotal story link:

https://www.pivotaltracker.com/story/show/78294508
### What was the issue?

DO numbers with leading zeros are crashing the workflow engine
### Resolution?

fixed gem to not try and decode strings with leading 0s
### How did you verify the fix?

hope and prayer
### Changes to deployments(new settings)?

none
### Screenshots:

n/a
### Delete Branch after Merge?

no
