### PR TITLE
Only let things that have this key pass.

### DIFF
--- a/lib/ruote/sequel/storage.rb
+++ b/lib/ruote/sequel/storage.rb
@@ -233,6 +233,8 @@ puts "put: got exception #{de.to_s}, try number #{i + 1}"
         docs
       end
 
+      docs.select { |doc| doc.has_key?('_id') }
+
       # (pass on the dataset.filter(:wfid => /regexp/) for now
       # since we have potentially multiple keys)
     end


### PR DESCRIPTION
### Base branch(merging into):
master
### Pivotal story link:
???
### What was the issue?
Workflow was crashing because of msgs w/ empty docs.
### Resolution?
docs must have the _id key to pass
### How did you verify the fix?
Workflow was alive.
### Changes to deployments(new settings)?
Make new release branch and put in gemfile after merge.
### Screenshots:
nope
### Delete Branch after Merge?
yes
